### PR TITLE
Specify provision format version 1

### DIFF
--- a/virter/exec-test.toml
+++ b/virter/exec-test.toml
@@ -1,3 +1,5 @@
+version = 1
+
 [[steps]]
 [steps.rsync]
 source = "."

--- a/virter/provision-docker.toml
+++ b/virter/provision-docker.toml
@@ -1,3 +1,5 @@
+version = 1
+
 [[steps]]
 [steps.shell]
 script = '''

--- a/virter/provision-podman.toml
+++ b/virter/provision-podman.toml
@@ -1,3 +1,5 @@
+version = 1
+
 [[steps]]
 [steps.shell]
 script = '''


### PR DESCRIPTION
Otherwise, `virter` assumes version 0 and fails