### PR TITLE
Disable SELinux label confinement

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -73,12 +73,18 @@ func (d DockerProvider) Create(ctx context.Context, cfg *ContainerConfig) (strin
 		extraHosts[i] = fmt.Sprintf("%s:%s", cfg.extraHosts[i].HostName, cfg.extraHosts[i].IP)
 	}
 
+	
+	// Disables SELinux label confinement
+	// Otherwise, systems using it might have permission issues with bind mounts
+	securityOpt := []string{"label=disable"}
+
 	hostConfig := &container.HostConfig{
 		NetworkMode: "host",
 		Mounts:      mounts,
 		DNS:         servers,
 		DNSSearch:   cfg.dnsSearchDomains,
 		ExtraHosts:  extraHosts,
+		SecurityOpt: securityOpt,
 	}
 
 	resp, err := d.client.ContainerCreate(ctx, config, hostConfig, nil, nil, cfg.name)

--- a/virter/exec-test.toml
+++ b/virter/exec-test.toml
@@ -1,3 +1,5 @@
+version = 1
+
 [[steps]]
 [steps.rsync]
 source = "."

--- a/virter/provision-docker.toml
+++ b/virter/provision-docker.toml
@@ -1,3 +1,5 @@
+version = 1
+
 [[steps]]
 [steps.shell]
 script = '''

--- a/virter/provision-podman.toml
+++ b/virter/provision-podman.toml
@@ -1,3 +1,5 @@
+version = 1
+
 [[steps]]
 [steps.shell]
 script = '''

--- a/virter/provision-podman.toml
+++ b/virter/provision-podman.toml
@@ -9,11 +9,6 @@ dnf install -y podman gcc
 curl -fsSL https://golang.org/dl/go1.18.10.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
 
-cat <<EOF > /etc/containers/containers.conf
-[containers]
-label=false
-EOF
-
 systemctl --user enable --now podman.socket
 
 podman --url unix:/run/user/0/podman/podman.sock image pull docker.io/hello-world


### PR DESCRIPTION
This should fix issues with systems using SELinux in Enforcing mode. 
Although this issue appears to occurs only with the `podman` provider, It may also have had affected the docker one.

Based on #1
Fixes LINBIT/virter#17
